### PR TITLE
fix: update gsh5 writer to v2.1, writing out time_ranges and lst_ranges

### DIFF
--- a/src/pygsdata/constants.py
+++ b/src/pygsdata/constants.py
@@ -15,4 +15,4 @@ KNOWN_TELESCOPES = {
     )
 }
 
-galactic_centre_lst = apc.Longitude(17.76111111111111 * apu.hourangle)
+galactic_centre_lst = apc.Longitude(17.7611666666666 * apu.hourangle)

--- a/src/pygsdata/gsdata.py
+++ b/src/pygsdata/gsdata.py
@@ -387,7 +387,7 @@ class GSData:
             # when the file format changes in a backwards-compatible way. The major
             # version is incremented when the file format changes in a way
             # that requires a new reader.
-            fl.attrs["version"] = "2.0"
+            fl.attrs["version"] = "2.1"
 
             meta = fl.create_group("metadata")
             self.telescope.write(meta.create_group("telescope"))
@@ -398,7 +398,9 @@ class GSData:
             )
 
             meta["times"] = self.times.jd
+            meta["time_ranges"] = self.time_ranges.jd
             meta["lsts"] = self.lsts.hour
+            meta["lst_ranges"] = self.lst_ranges.hour
             meta.attrs["data_unit"] = self.data_unit
             meta["loads"] = self.loads
             meta.attrs["history"] = repr(self.history)

--- a/src/pygsdata/readers.py
+++ b/src/pygsdata/readers.py
@@ -85,11 +85,12 @@ class _GSH5Readers:
         times = meta["times"][()]
         times = Time(times, format="jd", location=telescope.location)
 
+        extra_kw = {}
         if "time_ranges" in meta:
             time_ranges = meta["time_ranges"][()]
             time_ranges = Time(time_ranges, format="jd", location=telescope.location)
+            extra_kw["time_ranges"] = time_ranges
         else:
-            time_ranges = None
             warnings.warn(
                 "You wrote this file with a buggy version of pygsdata that did not "
                 "include time_ranges and lst_ranges in the file. The time_ranges and "
@@ -109,8 +110,7 @@ class _GSH5Readers:
         lsts = Longitude(meta["lsts"][()] * un.hourangle)
         if "lst_ranges" in meta:
             lst_ranges = Longitude(meta["lst_ranges"][()] * un.hourangle)
-        else:
-            lst_ranges = None
+            extra_kw["lst_ranges"] = lst_ranges
 
         lst_mask = lst_selector(
             lsts,
@@ -185,6 +185,5 @@ class _GSH5Readers:
             residuals=residuals,
             name=objname,
             effective_integration_time=intg_time,
-            time_ranges=time_ranges,
-            lst_ranges=lst_ranges,
+            **extra_kw,
         )

--- a/src/pygsdata/readers.py
+++ b/src/pygsdata/readers.py
@@ -137,7 +137,7 @@ class _GSH5Readers:
         )
 
         auxiliary_measurements = {
-            name: fl["auxiliary_measurements"][name][:]
+            name: fl["auxiliary_measurements"][name][time_mask]
             for name in fl["auxiliary_measurements"]
         } or None
 

--- a/src/pygsdata/select.py
+++ b/src/pygsdata/select.py
@@ -50,7 +50,6 @@ def select_freqs(
     *,
     freq_range: FreqRangeType | None = None,
     indx: np.ndarray | None = None,
-    **kwargs,
 ) -> GSData:
     """Select a subset of the frequency channels."""
     mask = freq_selector(data.freqs, freq_range=freq_range, indx=indx)


### PR DESCRIPTION
Fixes https://github.com/edges-collab/edges-analysis/issues/182 by writing out the `lst_ranges` and `time_ranges` to file so they can be read in consistently.