### PR TITLE
fix: save timestamps as strings rather than datetime objects

### DIFF
--- a/src/pygsdata/register.py
+++ b/src/pygsdata/register.py
@@ -48,7 +48,7 @@ def _register(func: callable, kind: RegKind) -> callable:
             "message": message,
             "function": func.__name__,
             "parameters": kw,
-            "timestamp": now,
+            "timestamp": now.strftime("%Y-%m-%d %H:%M:%S"),
         }
 
         kw = {"history": history}


### PR DESCRIPTION
Keep datetime objects in history as strings rather than datetime, to aid in hickling. Long term might be better to move some of the serialization stuff over to pygsdata
